### PR TITLE
Fix typo: one a month -> once a month

### DIFF
--- a/source/web-https.rst
+++ b/source/web-https.rst
@@ -40,6 +40,6 @@ to do anything.
     certificates when they are 60 days old. In pratice, the provided files will
     change every 1-2 months.
 
-    Make sure to either restart your service one a month, or watch the files for
+    Make sure to either restart your service once a month, or watch the files for
     changes and restart accordingly. Otherwise your service will use an
     outdated, invalid certificate.


### PR DESCRIPTION
I think "once" was the intention of the author.