### PR TITLE
remove Python 3.4

### DIFF
--- a/source/lang-python.rst
+++ b/source/lang-python.rst
@@ -17,7 +17,7 @@ Versions
 
 Release Types 
 -------------
-Each release branch of Python is fully supported for five years beginning with its initial stable release. For Python 2.7, this has been extended to ten years. We provide different point releases and apply security updates on a regular basis. Currently, these Python versions are available: 2.7, 3.4, 3.5, and 3.6. 
+Each release branch of Python is fully supported for five years beginning with its initial stable release. For Python 2.7, this has been extended to ten years. We provide different point releases and apply security updates on a regular basis. Currently, these Python versions are available: 2.7, 3.5, and 3.6. 
 
 Standard version
 ----------------
@@ -42,8 +42,6 @@ We update all versions on a regular basis. Once the `security support <https://d
 | Branch | State               | Security Support Until      |
 +========+=====================+=============================+
 | 2.7    | Bug fixes           | January 2020                |
-+--------+---------------------+-----------------------------+
-| 3.4    | Security fixes only | March 2019                  |
 +--------+---------------------+-----------------------------+
 | 3.5    | Security fixes only | September 2020              |
 +--------+---------------------+-----------------------------+


### PR DESCRIPTION
Since _Security Support_ for Python 2.4 ended in march 2019, we will remove it from our servers soon. 

See https://git.uberspace.is/uberspace/uberspace7/issues/975 for release information.