### PR TITLE
typo "separated"

### DIFF
--- a/source/background-network.rst
+++ b/source/background-network.rst
@@ -195,7 +195,7 @@ Impact on users
 While this architecture shouldn't restrict you in any way (ping us at hallo@uberspace.de,
 if it does!), there a few things to watch out for:
 
-* You have your own seperate ``127.0.0.1``. If you services listens on that, it
+* You have your own separate ``127.0.0.1``. If you services listens on that, it
   is only reachable within your uberspace. If you want to make use of our
   :ref:`web backends <backends>`, be sure to listen on ``0.0.0.0``.
 * When using the "classic" ``.htaccess`` method of providing your own web


### PR DESCRIPTION
ppl love to misspell this one 'cos of its phonetics.
German mnemonic: "Separee" (private room)