### PR TITLE
remove changelog for `v7.4.5`

### DIFF
--- a/source/changelog/2020-03-23_7.4.5.rst
+++ b/source/changelog/2020-03-23_7.4.5.rst
@@ -1,3 +1,0 @@
-Changed
--------
-* deleting a non-existent web backend now results in an error message


### PR DESCRIPTION
We never released `v7.4.5`, changes are included in `v7.5`; see [137](https://github.com/Uberspace/manual/pull/137/files).