### PR TITLE
Improve automagic HTTPS docs

### DIFF
--- a/source/web-https.rst
+++ b/source/web-https.rst
@@ -16,7 +16,7 @@ unwanted content.
 Let's encrypt
 =============
 
-We use `lua-resty-auto-ssl <https://github.com/GUI/lua-resty-auto-ssl>`_ to issue Let's Encrypt certificates for every external domain that is :ref:`connected to a Uberspace <web-domains>`. This happens automagically when a domain is requested by a client for the first time. For privacy reasons every domain gets its own certificate. We also handle the renewal, certificates will be renewed if they expire in less than 30 days.
+We use `lua-resty-auto-ssl <https://github.com/GUI/lua-resty-auto-ssl>`_ to issue Let's Encrypt certificates for every external domain that is :ref:`connected to a Uberspace <web-domains>`. This happens automagically when a domain (``Host`` header) is first seen by our webserver. For privacy reasons every domain gets its own certificate. We also handle the renewal, certificates will be renewed if they expire in less than 30 days.
 
 Certificate Access
 ------------------


### PR DESCRIPTION
I was totally misunderstanding this sentence and I believe this change makes it much more obvious what's happening. Assuming I understand it now.

> danke! Ich wollte gerade vorschlagen, ob man diesen Satz nicht in die Doku aufnehmen kann. Dann ist mir aufgefallen, es ist genau der Satz, den ich zuvor zitiert habe. Die Wortwahl ist nur sehr ungünstig. Bei "domain is requested by a client" bin ich davon ausgegangen, dass ich (der Client, euer Kunde) die Domain "requeste" also via "web domain add" hinzufüge. Man würde im Falle eines HTTP Clients o.ä. ja nicht davon reden, dass eine Domain requested wird. Zumindest ist mir die Formulierung so noch nicht begegnet.