### PR TITLE
Update database-mysql.rst

### DIFF
--- a/source/database-mysql.rst
+++ b/source/database-mysql.rst
@@ -37,6 +37,7 @@ Take a look into that file or execute ``my_print_defaults client`` to show it, l
 .. code-block:: console
 
   [eliza@dolittle ~]$ my_print_defaults client
+  --default-character-set=utf8mb4
   --user=eliza
   --password=SomeStrongPassword
 


### PR DESCRIPTION
Tested with a fresh U7.7.1.2 at cressida

The default-character-set is also displayed
```
[eliza@dolittle ~]$ my_print_defaults client
--default-character-set=utf8mb4
--user=eliza
--password=SomeStrongPassword
```


Note ``my_print_defaults clientreadonly`` currently does not display the charset as ``my_print_defaults client`` does.