### PR TITLE
replaced term "white list" with "allow list"

### DIFF
--- a/source/mail-access.rst
+++ b/source/mail-access.rst
@@ -78,7 +78,7 @@ Debugging
 
 The most common problems when using a mail client with an Uberspace account:
 
-* Some home routers, especially some *Speedport* models offered by Deutsche Telekom, block SMTP connections to servers that are not on an internal white list. You need to either disable that feature or add your Uberspace host to the white list. Please check your router's manual for instructions.
+* Some home routers, especially some *Speedport* models offered by Deutsche Telekom, block SMTP connections to servers that are not on an internal allow list. You need to either disable that feature or add your Uberspace host to the allow list. Please check your router's manual for instructions.
 * Similarly, some anti-virus applications block SMTP connections or modify the port. 
 * Some mail clients won't allow mail passwords that are longer than 16 characters.
 


### PR DESCRIPTION
Following many other projects and companies, I suggest using words like "allow list" and "deny list" over "white-" and "blacklist". (see e.g. https://www.heise.de/news/Nichtrassistische-Sprache-Abschied-von-Blacklist-und-Whitelist-4784291.html)