### PR TITLE
 replaced term "blacklist"

### DIFF
--- a/source/mail-mailboxes.rst
+++ b/source/mail-mailboxes.rst
@@ -43,7 +43,7 @@ Password Requirements
 
 Your mailbox password has to comply with a set of rules:
 
-- A minimum lenght of 8 characters.
+- A minimum length of 8 characters.
 - Not only letters.
 - Not only numbers.
 - Not on our deny list.

--- a/source/mail-mailboxes.rst
+++ b/source/mail-mailboxes.rst
@@ -46,10 +46,10 @@ Your mailbox password has to comply with a set of rules:
 - A minimum lenght of 8 characters.
 - Not only letters.
 - Not only numbers.
-- Not on our blacklist.
+- Not on our deny list.
 - A password score of ``>=4``.
 
-We **blacklist some passwords** we deem too common (like ``test1234``) or too easy to guess, e.g. if your mailbox name should be ``fn0rd``, we will reject ``testfn0rd`` as a password.
+We **prohibit the use of some passwords** we deem too common (like ``test1234``) or too easy to guess, e.g. if your mailbox name should be ``fn0rd``, we will reject ``testfn0rd`` as a password.
 
 In addition to the above, we also run `xcvbn <https://github.com/dwolfhub/zxcvbn-python>`_ over you password. This results in a score for your password, based on how easy it might be guessed and / or cracked (higher results mean a better estimated password strenght). We require a **password score** of at least ``4``.
 


### PR DESCRIPTION
Following many other projects and companies, I suggest using words like "allow list" and "deny list" over "white-" and "blacklist". (see e.g. https://www.heise.de/news/Nichtrassistische-Sprache-Abschied-von-Blacklist-und-Whitelist-4784291.html)