### PR TITLE
:pencil: explain possibility of missing notes for hotfixes

### DIFF
--- a/source/changelog.rst
+++ b/source/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 Below you can see the 5 most recent changes to Uberspace 7. For older changes,
 please refer to the :ref:`Changelog Archive <changelogarchive>`.
 
+.. include:: includes/hotfix-version.rst
+
 {# add/edit files in source/changelog to generate new changelog entries #}
 {% for entry in changelog_entries[:5] %}
 

--- a/source/changelog_archive.rst
+++ b/source/changelog_archive.rst
@@ -6,6 +6,8 @@ Changelog Archive
 
 This document contains all changes made to Uberspace 7.
 
+.. include:: includes/hotfix-version.rst
+
 {# add/edit files in source/changelog to generate new changelog entries #}
 {% for entry in changelog_entries %}
 

--- a/source/includes/hotfix-version.rst
+++ b/source/includes/hotfix-version.rst
@@ -2,6 +2,6 @@
 
 	*Sometimes the version shown on your host may be higher than the newest
 	version here.* In this case we might have applied additional fixes shortly
-	after an release or did internal changes without user impact. We deem
+	after a release or did internal changes without user impact. We deem
 	updates like these **hotfixes** and they are not necessarily included in
 	this changelog.

--- a/source/includes/hotfix-version.rst
+++ b/source/includes/hotfix-version.rst
@@ -1,0 +1,7 @@
+.. note::
+
+	*Sometimes the version shown on your host may be higher than the newest
+	version here.* In this case we might have applied additional fixes shortly
+	after an release or did internal changes without user impact. We deem
+	updates like these **hotfixes** and they are not necessarily included in
+	this changelog.

--- a/source/index.rst
+++ b/source/index.rst
@@ -10,13 +10,17 @@ Uberspace is a hosting platform targeted at people who want to look behind the s
 
 .. tip:: If you're looking for guides and how to install certain tools like `Ghost <https://lab.uberspace.de/en/guide_ghost.html>`_ and `WordPress <https://lab.uberspace.de/en/guide_wordpress.html>`_ check out the `⚛️ Uberlab <https://lab.uberspace.de/en/>`_!
 
-Version {{ newest_changelog_entry.version }} Changelog:
+#########
+Changelog
+#########
+
+Latest Version: **{{ newest_changelog_entry.version }}** ({{ newest_changelog_entry.date }})
 
 {{ newest_changelog_entry.text }}
 
-Released {{ newest_changelog_entry.date }}.
-
 For more information see the :doc:`full changelog <changelog>`.
+
+.. include:: includes/hotfix-version.rst
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
While we try to be thorough, not every hotfix might show up in our changelog. This adds a note to explain that.