### PR TITLE
Add tip for subdomain certificate generation

### DIFF
--- a/source/web-https.rst
+++ b/source/web-https.rst
@@ -12,6 +12,9 @@ domains, are automatically provided with a free certificate from
 users always use a secure connection to prevent eavesdropping and injection of
 unwanted content.
 
+.. tip::
+
+    Treat sudomains as normal :ref:`external domains <web-domains>` and the certificate will be generated for those, too.
 
 Let's encrypt
 =============


### PR DESCRIPTION
First I wasn't sure about the certificate generation of subdomains and just tried to add them as a normal domain and it worked. After that I saw the tip in `web-domains.rst`:

> Any subdomain that you wish to use needs to be added individually. 

But maybe it helps if it's also added to the certificate section.

What do you think?