### PR TITLE
docs: Check ``stderr` with ``supervisorctl``

### DIFF
--- a/source/daemons-supervisord.rst
+++ b/source/daemons-supervisord.rst
@@ -73,7 +73,7 @@ To get an overview of your services and their current status, run ``supervisorct
 Logging
 =======
 
-``supervisord`` logs are stored in ``~/logs/``. You can use ``supervisorctl tail my-daemon`` to view the log for ``my-daemon``. 
+``supervisord`` logs are stored in ``~/logs/``. You can use ``supervisorctl tail my-daemon`` and ``supervisorctl tail my-daemon stderr`` to view the log for ``my-daemon``. Type in ``supervisorctl tail`` to see available options.
 
 Further Reading
 ===============


### PR DESCRIPTION
I spend the afternoon yesterday to debug a particular problem with a service and couldn't see any error message. I contacted uberspace support (ticket [Uberspace.de #480399]) and Nico was so kind to email me back how to check ``stderr`` logs with ``supervisorctl``. Hope this helps other developers in the future.