### PR TITLE
Revert ":fire: rm deno docs from index"

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -92,6 +92,7 @@ For more information see the :doc:`full changelog <changelog>`.
    PHP <lang-php>
    Python <lang-python>
    NodeJS <lang-nodejs>
+   deno <lang-deno>
    Ruby <lang-ruby>
    golang <lang-golang>
    Rust <lang-rust>


### PR DESCRIPTION
This reverts commit 429c55a4d7acc486f95ca672660f172a2a354818.

While I released the docs too early, deno support will come. We have to wait till the next release though.