### PR TITLE
Update mail-forwarding.rst

### DIFF
--- a/source/mail-forwarding.rst
+++ b/source/mail-forwarding.rst
@@ -15,7 +15,7 @@ You can use forwardings in the form of ``$MAILBOX@$USER.uber.space``. If you hav
 Add forwards for a mailbox
 --------------------------
 
-You can configure forwardings with the ``uberspace mail user forward set <mailbox> <mail address>`` command.
+You can configure forwardings with the ``uberspace mail user forward set <mailbox> <mail address>`` command. You cannot configure forwardings for an existing mailbox that does not already use forwardings.
 
 To forward all mails from ``forwardme`` to ``mail@allcolorsarebeautiful.example`` run the following command:
 


### PR DESCRIPTION
It is not possible to configure/add forwarding for a mailbox that already exists and that does not already use forwarding. I propose to add a sentence to reflect this.