### PR TITLE
Update mail-access.rst

### DIFF
--- a/source/mail-access.rst
+++ b/source/mail-access.rst
@@ -92,4 +92,4 @@ If Mail.app complains that the Account or the SMTP server is offline, this is us
 .. glossary::
 
     your Hostname
-      You can find your hostname in the `Datasheet <https://uberspace.de/dashboard/datasheet>`_ section. It's always ``<something>.uberspace.de``.
+      You can find your hostname in the `Datasheet <https://uberspace.de/dashboard/datasheet>`_ section. It's always ``<username>.uber.space``.


### PR DESCRIPTION
<something>.uberspace.de seems wrong as it is not valid for uberspace 7 anymore? On needs to use <username>.uber.space which is the new hostname, as I am migrating I had no access to https://uberspace.de/dashboard/datasheet which may point the user to the fact that <username>.uber.space is the new hostname. 

Only the MX Record is set to <hostname>.uberspace.de, which makes the term hostname a little ambiguous (zweideutig).