### PR TITLE
:fire: deprecate PHP 7.2

### DIFF
--- a/source/lang-php.rst
+++ b/source/lang-php.rst
@@ -21,7 +21,7 @@ Versions
 
 Release types
 -------------
-Each release branch of PHP is fully supported for two years beginning with its initial stable release. We provide different point releases and apply security updates on a regular basis. Currently, these PHP versions are available: 7.2, 7.3 and 7.4.
+Each release branch of PHP is fully supported for two years beginning with its initial stable release. We provide different point releases and apply security updates on a regular basis. Currently, these PHP versions are available: 7.3 and 7.4.
 
 Standard version
 ----------------
@@ -35,7 +35,6 @@ Use ``uberspace tools version list php`` to show all selectable versions:
 .. code-block:: console
 
   [eliza@dolittle ~]$ uberspace tools version list php
-  - 7.2
   - 7.3
   - 7.4
   [eliza@dolittle ~]$
@@ -55,8 +54,8 @@ You can select the PHP version with :code:`uberspace tools version use php <vers
 
 .. code-block:: console
 
-  [eliza@dolittle ~]$ uberspace tools version use php 7.2
-  Selected PHP version 7.2
+  [eliza@dolittle ~]$ uberspace tools version use php 7.3
+  Selected PHP version 7.3
   The new configuration is adapted immediately. Patch updates will be applied automatically.
   [eliza@dolittle ~]$
 
@@ -68,7 +67,7 @@ You can check the selected version by executing ``uberspace tools version show p
 .. code-block:: console
 
   [eliza@dolittle ~]$ uberspace tools version show php
-  Using 'PHP' version: '7.2'
+  Using 'PHP' version: '7.3'
   [eliza@dolittle ~]$
 
 Update policy
@@ -79,8 +78,6 @@ We update all versions on a regular basis. Once the `security support <http://ph
 +--------+---------------------+------------------------+
 | Branch | State               | Security Support Until |
 +========+=====================+========================+
-| 7.2    | Active support      | 30 Nov 2020            |
-+--------+---------------------+------------------------+
 | 7.3    | Active support      | 6 Dec 2021             |
 +--------+---------------------+------------------------+
 | 7.4    | Active support      | 28 Nov 2022            |

--- a/source/lang-php.rst
+++ b/source/lang-php.rst
@@ -21,7 +21,7 @@ Versions
 
 Release types
 -------------
-Each release branch of PHP is fully supported for two years beginning with its initial stable release. We provide different point releases and apply security updates on a regular basis. Currently, these PHP versions are available: 7.3 and 7.4.
+Each release branch of PHP is fully supported for two years beginning with its initial stable release. We provide different point releases and apply security updates on a regular basis.
 
 Standard version
 ----------------


### PR DESCRIPTION
We will deprecate PHP 7.2 with the next release (probably `7.8.1` ~ 2020-12-14).