### PR TITLE
Make the distinction between "real" mailboxes and forwardings more clear

### DIFF
--- a/source/mail-forwarding.rst
+++ b/source/mail-forwarding.rst
@@ -7,7 +7,7 @@ forwarding mails
 configure forwarding
 ====================
 
-You can use forwardings in the form of ``$MAILBOX@$USER.uber.space``. If you have :ref:`set up additional domains <mail-domains>`, ``$MAILBOX@$DOMAIN`` will also work.
+You can set up forwardings for addresses that will look like ``$MAILBOX@$USER.uber.space``. If you have :ref:`set up additional domains <mail-domains>`, ``$MAILBOX@$DOMAIN`` will also work.
 
 .. warning::
     We do not forward mails with a :doc:`spam score >= 10 <mail-spam>`. This is crucial due to policy reasons at nearly any mail provider and makes sure the reputation of our servers stays fine.
@@ -15,7 +15,7 @@ You can use forwardings in the form of ``$MAILBOX@$USER.uber.space``. If you hav
 Add forwards for a mailbox
 --------------------------
 
-You can configure forwardings with the ``uberspace mail user forward set <mailbox> <mail address>`` command. You cannot configure forwardings for an existing mailbox that does not already use forwardings.
+You can configure forwardings with the ``uberspace mail user forward set <mailbox> <mail address>`` command. You cannot create a forwarding for an already existing mailbox.
 
 To forward all mails from ``forwardme`` to ``mail@allcolorsarebeautiful.example`` run the following command:
 


### PR DESCRIPTION
I found it confusing to read and only figured out while trying how it was meant; that mailboxes are a different concept from forwards and mutually exclusive. I think these changes transport that a bit better.