### PR TITLE
Fix typo

### DIFF
--- a/source/mail-mailboxes.rst
+++ b/source/mail-mailboxes.rst
@@ -51,7 +51,7 @@ Your mailbox password has to comply with a set of rules:
 
 We **prohibit the use of some passwords** we deem too common (like ``test1234``) or too easy to guess, e.g. if your mailbox name should be ``fn0rd``, we will reject ``testfn0rd`` as a password.
 
-In addition to the above, we also run `xcvbn <https://github.com/dwolfhub/zxcvbn-python>`_ over you password. This results in a score for your password, based on how easy it might be guessed and / or cracked (higher results mean a better estimated password strenght). We require a **password score** of at least ``4``.
+In addition to the above, we also check your password using `xcvbn <https://github.com/dwolfhub/zxcvbn-python>`_. This results in a score for your password, based on how easy it might be guessed and / or cracked (higher results mean a better estimated password strenght). We require a **password score** of at least ``4``.
 
 If we reject your password, we try to give you an error messages that explains why. Hopefully it will help you to choose a fitting alternative.
 


### PR DESCRIPTION
Instead "over you password", it should be "over your password". I rewrote the text a bit to IMHO more match an English style.