### PR TITLE
Fixed typo in link

### DIFF
--- a/source/firstday-ubernauts.rst
+++ b/source/firstday-ubernauts.rst
@@ -63,7 +63,7 @@ Databases
 Miscellaneous
 =============
 
-- If we had opened a port for your software on U6, you may not be able to get the same port again on U7. You can open random ports by your own, see :ref:`opening ports <basic-ports>`.
+- If we had opened a port for your software on U6, you may not be able to get the same port again on U7. You can open random ports by your own, see :ref:`opening ports <basics-ports>`.
 
 - We no longer support outdated software like CGI, PHP5 etc. on U7. You may be able to get these run by installing and setting them up yourself but we cannot support you with problems in doing so.
 


### PR DESCRIPTION
Fixed a typo to correctly link to the page regarding opening ports.

Note: I'm not sure why GitHub shows a change in line 110. I didn't change anything there.