### PR TITLE
create verbose u6-namespace description

### DIFF
--- a/source/firstday-ubernauts.rst
+++ b/source/firstday-ubernauts.rst
@@ -13,7 +13,7 @@ Congratulations! You have just finished your move from Uberspace 6 to Uberspace 
 
 
 Web Domains
-===========
+-----------
 
 - On U7 you will have a new short and nice default domain, independent from your current host: **https://isabell.uber.space** (where ``isabell`` is your username).
 
@@ -29,7 +29,7 @@ Web Domains
 
 
 Mailing
-=======
+-------
 
 - According to your new default domain, you also have an adequate default email address: **isabell@uber.space** (where ``isabell`` is your username).
 
@@ -43,7 +43,7 @@ Mailing
 
 
 Logging and Debugging
-=====================
+---------------------
 
 - Logging is disabled by default and you have to :ref:`enable <web-logs>` different types of logs.
 
@@ -51,7 +51,7 @@ Logging and Debugging
 
 
 Databases
-=========
+---------
 
 - There is now a central instance for Adminer at `https://mysql.uberspace.de/adminer <https://mysql.uberspace.de/adminer>`_
 
@@ -61,7 +61,7 @@ Databases
 
 
 Miscellaneous
-=============
+-------------
 
 - If we had opened a port for your software on U6, you may not be able to get the same port again on U7. You can open random ports by your own, see :ref:`opening ports <basics-ports>`.
 
@@ -73,7 +73,7 @@ Miscellaneous
 
 
 New features
-============
+------------
 
 - You can :ref:`upgrade your storage <billing>` and use more storage space than the default 10GB.
 
@@ -87,7 +87,7 @@ New features
 
 
 Specific changes for automatically migrated hosts
-=================================================
+-------------------------------------------------
 
 In February 2021 we started to migrate all hosts automatically to U7. This process is still ongoing, you will be informed by mail before your host is migrated. Some changes apply only for accounts on theses hosts:
 
@@ -95,7 +95,7 @@ In February 2021 we started to migrate all hosts automatically to U7. This proce
 
 - Even when hostname and IPv6 address will be kept, you might have to change the MX record for your domain if you use it like ``mail.mydomain.tld.``, on U7 you will have to set it always to the hostname like ``stardust.uberspace.de.``
 
-- If you used namespaces on U6, the ``~/.qmail-default`` will redirect all incoming mails to a new Maildir ``~/namespace-collector``. Namespaces are no longer supported on U7 and you will need to distinguish the namespaces in other ways. You will find your old ``.qmail-*`` files in the new folder ``~/old-dot-qmail``.
+- If you used mail namespaces on U6 your mailboxes will no longer work, please read :ref:`here <u6-namespaces>` how to solve this.
 
 - If you used the external Marianna DB Server on U6, you will find a dump of your data and structure in the file ``~/UBERSPACE6_marianna.sql``.
 
@@ -103,7 +103,7 @@ In February 2021 we started to migrate all hosts automatically to U7. This proce
 
 
 Unfinished Features
-===================
+-------------------
 
 - On U6 the Spamfilter could be trained specifically for your Uberspace, we are trying to make this feature working again on U7, but at this time the spam filters are only trained per host.
 

--- a/source/u6-namespaces.rst
+++ b/source/u6-namespaces.rst
@@ -1,0 +1,101 @@
+.. _u6-namespaces:
+
+#######################################################
+Mail namespaces from automatically migrated accounts from U6
+#######################################################
+
+On U6 you had the possibility to use domain namespaces for your mail accounts. Using this feature you could create mailboxes just for a specific domain on your Uberspace like this:
+
+  - anna@example1.com
+  - arthur@example2.com
+
+Because this resulted in a heavy complicated setup on U6 and since we recommend to use only *one domain for one uberspace* anyway, this feature is no longer supported on U7.
+After auto migration, your mailboxes will look like this if you used namespaces:
+
+.. code-block:: bash
+
+  [isabell@stardust ~]$ uberspace mail domain list
+  example1.com
+  example2.com
+
+  [isabell@stardust ~]$ uberspace mail user list
+  namespace1-anna
+  namespace2-arthur
+
+  [isabell@stardust ~]$ ls ~/users
+  namespace1-anna namespace2-arthur
+
+The result would be these mail addresses:
+
+  - namespace1-anna@example1.com
+  - namespace1-anna@example2.com
+  - namespace2-arthur@example1.com
+  - namespace2-arthur@example2.com
+
+And the original used addresses like on U6 would be rejected by our mailserver. To approach this issue in auto migration we do the following steps with namespaced mailboxes:
+
+  - all your ``~/.qmail-*`` files are moved to ``~/old-dot-qmail``
+  - the new ``~/.qmail-default`` will redirect *all new* incoming emails to ``~/namespace-collector``
+
+This is a temporary setup to give you the chance and solve the namespaces in your own preferred way.
+
+Example for solving the namespaces
+----------------------------------
+
+One possibility to migrate your namespace configuration to U7 is to stay on a single Uberspace and use all mailboxes for all domains, like this:
+
+  - anna@example1.com
+  - anna@example2.com
+  - arthur@example1.com
+  - arthur@example2.com
+
+First you have to add the correct mailboxes:
+
+.. code-block:: bash
+
+  [isabell@stardust ~]$ uberspace mail user add anna
+  Enter a password for the mailbox:
+  Please confirm your password:
+  New mailbox created for user: 'anna', it will be live in a few minutes...
+
+  [isabell@stardust ~]$ uberspace mail user add arthur
+  Enter a password for the mailbox:
+  Please confirm your password:
+  New mailbox created for user: 'arthur', it will be live in a few minutes...
+
+  [isabell@stardust ~]$ uberspace mail user list
+  namespace1-anna
+  namespace2-arthur
+  anna
+  arthur
+
+Then you will have to remove the temporary redirection to ``~/namespace-collector``:
+
+.. code-block:: bash
+
+  [isabell@stardust ~]$ rm ~/.qmail-default
+  [isabell@stardust ~]$ uberspace mail spamfolder enable
+
+If you want to have the old mails in the new mailboxes, you can just copy them:
+
+.. code-block:: bash
+
+  [isabell@stardust ~]$ rsync -rtu ~/users/namespace1-anna ~/users/anna
+  [isabell@stardust ~]$ rsync -rtu ~/users/namespace2-arthur ~/users/arthur
+
+Because there might be issues with incorrect index files, you should just remove them (they are automatically recreated):
+
+.. code-block:: bash
+
+  [isabell@stardust ~]$ find ~/users/ -name "dovecot*" -delete
+
+To finish this you might want to remove the old namespaced mailboxes:
+
+.. code-block:: bash
+
+  [isabell@stardust ~]$ uberspace mail user del namespace1-anna
+  Mailbox for user 'namespace1-anna' deleted.
+  [isabell@stardust ~]$ uberspace mail user del namespace2-arthur
+  Mailbox for user 'namespace1-arthur' deleted.
+
+Now you have a clean and U7 compatible mail setup.

--- a/source/u6-namespaces.rst
+++ b/source/u6-namespaces.rst
@@ -99,3 +99,7 @@ To finish this you might want to remove the old namespaced mailboxes:
   Mailbox for user 'namespace1-arthur' deleted.
 
 Now you have a clean and U7 compatible mail setup.
+
+.. note::
+
+ Between migration and fixing the namespaces, there might have been redirected some emails to ``~/namespace-collector``. You will have to decide by yourself how to deal with them, for example copying them to one of your mailboxes or create an new mailbox ``namespace-collector`` and move them there to check with your email client.


### PR DESCRIPTION
because we have to interfere into the users mailbox namespaces when auto migrating to U7, we should tell them the backgrounds and how to solve it