### PR TITLE
web-headers: add blocking google FLoC as example

### DIFF
--- a/source/web-headers.rst
+++ b/source/web-headers.rst
@@ -255,8 +255,8 @@ If you removed or replaced security headers in the past and would like to restor
     X-Frame-Options: SAMEORIGIN
     X-Xss-Protection: 1; mode=block
 
-Generally helpful examples
-==========================
+Examples
+========
 
 Blocking Google FLoC
 --------------------

--- a/source/web-headers.rst
+++ b/source/web-headers.rst
@@ -258,10 +258,10 @@ If you removed or replaced security headers in the past and would like to restor
 Examples
 ========
 
-Blocking Google FLoC
---------------------
+Disable Google's FLoC
+---------------------
 
-As anounced in April of 2021 Google is moving to using a new technology to track users across the web using its maret share with browsers. This is a way to undermine this effort on your site.
+As anounced in April of 2021, Google is moving to use a new technology called FLoC to track users across the web. To disable FLoC for a website, you can add a ``Permissions-Policy`` header:
 
 .. code-block:: console
 

--- a/source/web-headers.rst
+++ b/source/web-headers.rst
@@ -254,3 +254,16 @@ If you removed or replaced security headers in the past and would like to restor
     X-Content-Type-Options: nosniff
     X-Frame-Options: SAMEORIGIN
     X-Xss-Protection: 1; mode=block
+
+Generally helpful examples
+==========================
+
+Blocking Google FLoC
+--------------------
+
+As anounced in April of 2021 Google is moving to using a new technology to track users across the web using its maret share with browsers. This is a way to undermine this effort on your site.
+
+.. code-block:: console
+
+  [isabell@philae ~]$ uberspace web header set / Permissions-Policy "interest-cohort=()"
+  Set header "Permissions-Policy: interest-cohort=()" for /


### PR DESCRIPTION
- adds an example section to web-headers.rst
- adds blocking google FLoC with HTTP headers to that section
Google FLoC is the new [as of 04/2021] way of google to track users. this documents how to block that on a site on an uberspace.