### PR TITLE
simplify forward delete text

### DIFF
--- a/source/mail-forwarding.rst
+++ b/source/mail-forwarding.rst
@@ -42,7 +42,7 @@ You can list your existing forwardings using the ``uberspace mail user forward l
 Delete forwards for a mailbox
 -----------------------------
 
-You can delete forwardings using the ``uberspace mail user forward del <mailbox>`` command. This will delete the specified alias, so mails sent to it will no longer be delivered (exept if you set up a catchall address). To delete forwarding for ``forwardme``, run the following command:
+You can delete forwardings using the ``uberspace mail user forward del <mailbox>`` command, for example to delete forwarding for ``forwardme``, run the following command:
 
 .. code-block:: bash
 


### PR DESCRIPTION
its obvious that deleting a mail forward address will have the result that the address no longer works and a catch all would take over. IMHO its not necessary to put a reference here