### PR TITLE
update qmail warning #320

### DIFF
--- a/source/mail-forwarding.rst
+++ b/source/mail-forwarding.rst
@@ -56,4 +56,6 @@ spam filtering
 With enabled :doc:`spam filtering <mail-spam>` we do not forward mails with a spam score greater than 5. These mails get sorted into ``~/users/$MAILBOX/.Spam``.
 
 .. warning::
-    In the past on the outdated product version Uberspace 6 we encouraged users to manipulate ``.qmail`` files for forwarding and controlling the email flow. This is technically still possible on U7 but will strongly interfere with our standard email setup that should be configured by using the ``uberspace mail`` commands. Because of this, we no longer provide support for problems originating from customly changed ``.qmail`` files. Please also be aware, that our setup might change in the future and break your now working custom configurations.
+    In the past, with the outdated product version Uberspace 6 we encouraged users to manipulate ``.qmail`` files for forwarding and controlling the email flow. This is technically still possible on U7 but will strongly interfere with our standard email setup that should be configured by using the ``uberspace mail`` commands. 
+    
+    Because of this, we no longer can support you in technical issues with qmail programming but recommend you to move your mail setup to the ``uberspace mail`` tools. The qmail configuration is still available and we also use the ``.qmail-default`` file to configure the spamfolder, but this might change in the future and break your custom configurations.


### PR DESCRIPTION
to be hones, the old text was not so bad, but some users might have misunderstood it as "delete all your .qmail immediately files because it is broken" the updated text is IMHO a bit verbose, youre decision @nichtmax 