### PR TITLE
Note on error when trying to add subdomain

### DIFF
--- a/source/web-domains.rst
+++ b/source/web-domains.rst
@@ -47,7 +47,10 @@ Because we check on each host if a domain is already under control of another us
 
 Then you can just add the subdomain *first* on the one user and *then* the main domain on the other user.
 
-.. note:: We very much encourage to use separate uberspace accounts for separate projects or apps and so far subdomains. And you shouldn't usually run in this problem because in most cases you won't end up with different users on the same host.
+.. note::
+  We very much encourage you to use separate Uberspace accounts for separate projects or apps and so for subdomains. And you shouldn't usually run into this problem because in most cases you won't end up with different users on the same host.
+  
+  Note that you will also encounter this error if the main domain is configured as a mail domain (and not as web domain) on another Uberspace account.
 
 Removal
 =======


### PR DESCRIPTION
Note explicitly that domain is compared with web and mail domains of other accounts.
(I just tried to add a subdomain to the web configuration of a second account, deleted the main domain from the web config of the first account and still got the error message. Took me a few minutes to figure out that I had to delete the main domain from the mail configuration, as well.)

Also fixes a few typos.