### PR TITLE
:fire: fix dead link in mail-access.rst

### DIFF
--- a/source/mail-access.rst
+++ b/source/mail-access.rst
@@ -82,13 +82,6 @@ The most common problems when using a mail client with an Uberspace account:
 * Similarly, some anti-virus applications block SMTP connections or modify the port.
 * Some mail clients won't allow mail passwords that are longer than 16 characters.
 
-Apple Mail.app
---------------
-
-If Mail.app complains that the Account or the SMTP server is offline, this is usually caused by the `Automatically manage connection settings <https://support.apple.com/en-us/HT204208>`_ option. If this option is active, Apple Mail sometimes replaces the correct settings with incorrect ones, blocking access to the account. You can safely turn off the setting and correct the settings.
-
-----
-
 .. glossary::
 
     Hostname

--- a/source/mail-access.rst
+++ b/source/mail-access.rst
@@ -82,6 +82,13 @@ The most common problems when using a mail client with an Uberspace account:
 * Similarly, some anti-virus applications block SMTP connections or modify the port.
 * Some mail clients won't allow mail passwords that are longer than 16 characters.
 
+Apple Mail.app
+--------------
+
+If Mail.app complains that the Account or the SMTP server is offline, this is usually caused by the `Automatically manage connection settings <https://support.apple.com/guide/mail/cpmlprefacctadv>`_ option. If this option is active, Apple Mail sometimes replaces the correct settings with incorrect ones, blocking access to the account. You can safely turn off the setting and correct the settings.
+
+----
+
 .. glossary::
 
     Hostname


### PR DESCRIPTION
Remove the Apple Mail.app section - Apple deleted the article, so the link was dead and the underlying problem doesn't seem to occur anymore either.