### PR TITLE
Use numeric comparison in Sieve filter example

### DIFF
--- a/source/mail-filters.rst
+++ b/source/mail-filters.rst
@@ -47,10 +47,10 @@ In this example we sort mails from a mailinglist into a folder, sort mails to ``
 
 .. code-block:: cfg
 
-    require ["fileinto", "reject", "relational"];
+    require ["fileinto", "reject", "relational", "comparator-i;ascii-numeric"];
 
     # Mails with a spam score greater than 4 are probably SPAM, sort them and stop
-    if header :value "ge" "X-Rspamd-Score" "4"
+    if header :value "ge" :comparator "i;ascii-numeric" "X-Rspamd-Score" "4"
     {
         fileinto "Spam";
         stop;


### PR DESCRIPTION
Using "i;ascii-numeric" for spam score check, as default comparison gives wrong results for values greater than 10