### PR TITLE
Make sure the Spam-score is not negative

### DIFF
--- a/source/mail-filters.rst
+++ b/source/mail-filters.rst
@@ -50,7 +50,9 @@ In this example we sort mails from a mailinglist into a folder, sort mails to ``
     require ["fileinto", "reject", "relational", "comparator-i;ascii-numeric"];
 
     # Mails with a spam score greater than 4 are probably SPAM, sort them and stop
-    if header :value "ge" :comparator "i;ascii-numeric" "X-Rspamd-Score" "4"
+    if allof (
+      not header :matches "X-Rspamd-Score" "-*",
+      header :value "ge" :comparator "i;ascii-numeric" "X-Rspamd-Score" "4")
     {
         fileinto "Spam";
         stop;


### PR DESCRIPTION
The previous rule lead to messages with negative spam score lower than –4 to be considered SPAM because apparently i;ascii-numeric does not handle negative numbers. 
Edit: Only now did I find issue #363 – this PR would resolve that issue.

cf. https://doc.dovecot.org/configuration_manual/sieve/examples/#direct-filtering-using-message-header  
»Be very careful when matching against spam score headers using the relational extension and the i;ascii-numeric comparator. This comparator can only be used to match unsigned integers. Strings that do not begin with a digit character represent positive infinity and will therefore always be larger than any score mentioned in your rule! That is why the above example first checks the minus sign explicitly.«