### PR TITLE
Avoid moving mails w/ negative spam value to spam

### DIFF
--- a/source/mail-filters.rst
+++ b/source/mail-filters.rst
@@ -47,10 +47,10 @@ In this example we sort mails from a mailinglist into a folder, sort mails to ``
 
 .. code-block:: cfg
 
-    require ["fileinto", "reject", "relational", "comparator-i;ascii-numeric"];
+    require ["fileinto", "reject", "relational"];
 
     # Mails with a spam score greater than 4 are probably SPAM, sort them and stop
-    if header :value "ge" :comparator "i;ascii-numeric" "X-Rspamd-Score" "4"
+    if header :contains"X-Rspamd-Bar" "++++"
     {
         fileinto "Spam";
         stop;


### PR DESCRIPTION
When using the proposed rule to filter spam, mails with negative spam value are moved to spam folder. Filtering based on the occurrence of a certain amount of symbols is more robust and doesn't need the acsii-comparator extension.