### PR TITLE
Revert "Use numeric comparison in Sieve filter example"

### DIFF
--- a/source/mail-filters.rst
+++ b/source/mail-filters.rst
@@ -47,10 +47,10 @@ In this example we sort mails from a mailinglist into a folder, sort mails to ``
 
 .. code-block:: cfg
 
-    require ["fileinto", "reject", "relational", "comparator-i;ascii-numeric"];
+    require ["fileinto", "reject", "relational"];
 
     # Mails with a spam score greater than 4 are probably SPAM, sort them and stop
-    if header :value "ge" :comparator "i;ascii-numeric" "X-Rspamd-Score" "4"
+    if header :value "ge" "X-Rspamd-Score" "4"
     {
         fileinto "Spam";
         stop;


### PR DESCRIPTION
Reverts Uberspace/manual#444

`i;ascii-numeric` is a really bad idea as it can't handle signed numerics, so `-5.6` is interpreted the same as `5.6` and both are treated as spam.