### PR TITLE
Fix broken link in lang-python

### DIFF
--- a/source/lang-python.rst
+++ b/source/lang-python.rst
@@ -21,7 +21,7 @@ Versions
 
 Release Types
 -------------
-Each release branch of Python is fully supported for five years beginning with its initial stable release. For Python 2.7, this has been extended to ten years. For more details see `Update Policy <https://manual.uberspace.de/lang-python/#update-policy>`_.
+Each release branch of Python is fully supported for five years beginning with its initial stable release. For Python 2.7, this has been extended to ten years. For more details see :ref:`Update Policy <update-policy-python>`.
 
 Standard version
 ----------------
@@ -39,6 +39,9 @@ To specify version 2.7 in a `shebang <https://en.wikipedia.org/wiki/Shebang_(Uni
 
 Update Policy
 -------------
+
+.. _update-policy-python:
+
 
 We update all versions of Python on a regular basis. Once the `security support <https://docs.python.org/devguide/index.html#branchstatus>`_ ends, the branch reaches its end of life, is no longer supported and will be removed from our servers.
 


### PR DESCRIPTION
The page used to contain a hardcoded link which probably broken when the url scheme was updated from `/lang-python/` to `/lang-python.html`.