### PR TITLE
mail-access.rst: Be more explicit about the hostname

### DIFF
--- a/source/mail-access.rst
+++ b/source/mail-access.rst
@@ -90,4 +90,4 @@ If Apple Mail complains that the Account or the SMTP server is offline, it is us
 .. glossary::
 
     Hostname
-      You can find your hostname in the `Datasheet <https://uberspace.de/dashboard/datasheet>`_ section. It's always ``<something>.uberspace.de``, e.g. ``sirius.uberspace.de`` and not ``<login>.uber.space``. Using the latter will create a certificate hostname mismatch.
+      You can find your hostname in the `Datasheet <https://uberspace.de/dashboard/datasheet>`_ section. It's always ``<something>.uberspace.de``, e.g. ``stardust.uberspace.de`` and not ``<login>.uber.space``. Using the latter will create a certificate hostname mismatch.

--- a/source/mail-access.rst
+++ b/source/mail-access.rst
@@ -90,4 +90,4 @@ If Apple Mail complains that the Account or the SMTP server is offline, it is us
 .. glossary::
 
     Hostname
-      You can find your hostname in the `Datasheet <https://uberspace.de/dashboard/datasheet>`_ section. It's always ``<something>.uberspace.de``.
+      You can find your hostname in the `Datasheet <https://uberspace.de/dashboard/datasheet>`_ section. It's always ``<something>.uberspace.de``, e.g. ``sirius.uberspace.de`` and not ``<login>.uber.space``. Using the latter will create a certificate hostname mismatch.


### PR DESCRIPTION
Add an explicit example and counter-example, mentioning the certificate problem if not respected.