### PR TITLE
replace php version 8.0 with 8.1

### DIFF
--- a/source/lang-php.rst
+++ b/source/lang-php.rst
@@ -46,8 +46,8 @@ You can select the PHP version with :code:`uberspace tools version use php <vers
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ uberspace tools version use php 8.0
-  Selected PHP version 8.0
+  [isabell@stardust ~]$ uberspace tools version use php 8.1
+  Selected PHP version 8.1
   The new configuration is adapted immediately. Patch updates will be applied automatically.
   [isabell@stardust ~]$
 
@@ -59,7 +59,7 @@ You can check the selected version by executing ``uberspace tools version show p
 .. code-block:: console
 
   [isabell@stardust ~]$ uberspace tools version show php
-  Using 'PHP' version: '8.0'
+  Using 'PHP' version: '8.1'
   [isabell@stardust ~]$
 
 Update policy


### PR DESCRIPTION
PHP 8.0 is end of life and will be deprecated. I guess we can update the examples to PHP 8.1.