### PR TITLE
Add "verify that it works" section

### DIFF
--- a/source/web-backends.rst
+++ b/source/web-backends.rst
@@ -56,6 +56,25 @@ To set the default backend to an application listening on port 1024 (for example
 
   [isabell@stardust ~]$
 
+verify
+===============
+
+You can check that your application is accessible with curl:
+
+.. code-block:: console
+
+  [isabell@stardust ~]$ curl -I isabell.uber.space
+  HTTP/1.1 200 OK
+  Date: Sun, 04 Feb 2024 10:54:07 GMT
+  Content-Type: text/html; charset=UTF-8
+  Content-Length: 444
+  Connection: keep-alive
+  Server: Apache/2.4.58 (Unix)
+  Last-Modified: Tue, 26 Oct 2021 18:45:26 GMT
+  ETag: "1bc-5cf45e182b8f0"
+  Accept-Ranges: bytes
+
+
 specific path
 -------------
 


### PR DESCRIPTION
Motivation: I was trying to set up flask and thought I had it correctly. Then I wanted to check if it works and did `curl <IP>` as well as `curl <myusername>.uber.space` and in both cases I did not get a response from my application, but instead default html (see below). I needed to add `-I` to curl to get HTTP 200. The lab guide I was using did not mention it, but I looked up the django guide based on GH issues saying it's similar and I found that tip there (https://lab.uberspace.de/guide_django/?highlight=django#finishing-installation). I was thinking about adding it to the Flask guide but I realized 'web backends' might be better. 

_______

Having written this, I realized the HTTP 200 may be still coming from the "default" html and not my application. I'm nevertheless leaving this PR, maybe you can verify and decide what's best to write in the section!