### PR TITLE
Correction of the support periods of the available PHP versions

### DIFF
--- a/source/lang-php.rst
+++ b/source/lang-php.rst
@@ -72,11 +72,11 @@ We update all versions on a regular basis. Once the `security support <http://ph
 +========+=====================+========================+
 | 8.0    | Deprecated          | 26 Nov 2023            |
 +--------+---------------------+------------------------+
-| 8.1    | Active support      | 25 Nov 2024            |
+| 8.1    | Active support      | 31 Dec 2025            |
 +--------+---------------------+------------------------+
-| 8.2    | Active support      | 08 Dec 2025            |
+| 8.2    | Active support      | 31 Dec 2026            |
 +--------+---------------------+------------------------+
-| 8.3    | Active support      | 23 Nov 2026            |
+| 8.3    | Active support      | 31 Dec 2027            |
 +--------+---------------------+------------------------+
 
 .. include:: includes/deprecation.rst


### PR DESCRIPTION
With the successful vote on https://wiki.php.net/rfc/release_cycle_update, the support period for PHP versions has changed: https://www.php.net/supported-versions.php