### PR TITLE
config-is-catchall: fix example out of sync with description

### DIFF
--- a/source/migration/qmail/reports/config-is-catchall.rst
+++ b/source/migration/qmail/reports/config-is-catchall.rst
@@ -42,7 +42,7 @@ Then on the mailbox ``catchall-mailbox`` you need to configure with Sieve filter
 .. code-block::
 
   require ["fileinto", "reject"];
-  if address :matches "to" "hallo-*@*" {
+  if address :matches "to" "shops-*@*" {
     keep;
   } else {
     reject;


### PR DESCRIPTION
The description text mentions `shops-*@` as example e-mail, but the sieve code uses `hallo-*@`. This commit brings both back in sync by using `shops-*@` consistently.