### PR TITLE
Add link to sieve doc

### DIFF
--- a/source/migration/qmail/reports/config-is-catchall.rst
+++ b/source/migration/qmail/reports/config-is-catchall.rst
@@ -36,7 +36,7 @@ Then you configure the catchall to forward mails to this mailbox:
  [isabell@stardust ~]$ uberspace mail catchall set catchall-mailbox
  Mails, which cannot be matched to a mailbox, will be sent to catchall-mailbox.
 
-Then on the mailbox ``catchall-mailbox`` you need to configure with Sieve filters, that all mails **except** mails to
+Then on the mailbox ``catchall-mailbox`` you need to configure with :doc:`Sieve filters<mail-filters>`, that all mails **except** mails to
 ``shops-*@`` will be rejected:
 
 .. code-block::


### PR DESCRIPTION
It took me far too long to learn what Sieve is and that there was already an explanation in the documentation about Sieve filters. 

Background: While running the `uberspace migration qmail check` command, I was instructed to see more information at https://manual.uberspace.de/migration/qmail/reports/config-is-catchall. There, I read about this new concept called "Sieve" and that I should configure it, but I had never heard of it before. So I started searching and learning about it, and I had already begun writing an email to support to ask where I could configure Sieve filters. Then I discovered that there was already a page in the documentation covering this topic.