### PR TITLE
Improved filter to match previous behaviour better

### DIFF
--- a/source/migration/qmail/reports/config-is-catchall.rst
+++ b/source/migration/qmail/reports/config-is-catchall.rst
@@ -42,11 +42,13 @@ Then on the mailbox ``catchall-mailbox`` you need to configure with :doc:`Sieve 
 .. code-block::
 
   require ["fileinto", "reject"];
-  if address :matches "to" "shops-*@*" {
+  if anyof (
+    header :matches "Delivered-To" "*-shops-*",
+    header :matches "Delivered-To" "*-newsletter-*"
+  ) {
     keep;
-  } else {
+ } else {
     reject;
-  }
-
+ }
 This example script will keep the mails in the new mailbox, but you can also use ``fileinto`` to store them in specific
-folders or forward them to another mailaddress with ``redirect``.
+folders or forward them to another mailaddress with ``redirect``. To just get rid of mail not matching the patterns use ``discard`` instead of ``reject``.


### PR DESCRIPTION
The current sieve filter only works for directly addressed mail. If the address isn't in one of the headers caught by ``address :matches "to"`` it doesn't work. This is the case for redirected mails and many mailing lists. Under the previous qmail subaddress system, those messages were caught.

Using the ``delivered-to`` header all mail delivered to subaddresses are delivered as before.

Minor changes:

* Condition with "anyof" to allow for multiple subaddresses
* Added comment regarding discard as alternative to reject